### PR TITLE
Use back nav in editor navbar

### DIFF
--- a/cms/src/lib/components/EditorNavbar.svelte
+++ b/cms/src/lib/components/EditorNavbar.svelte
@@ -72,7 +72,7 @@
     }
 
     function onBackNav() {
-        window.location.hash = '';
+        history.back()
     }
 
     onMount(() => {


### PR DESCRIPTION
Changing the hash was causing the dashboard to navigate back to the editor on back nav after the editor was visited.

This ensures that back nav from the dashboard always navigates to the page that initially navigated to the dashboard.