### PR TITLE
Fix duplicate UI issue

### DIFF
--- a/cms/src/main.js
+++ b/cms/src/main.js
@@ -1,8 +1,20 @@
 import './main.css';
 import App from './lib/App.svelte';
 
-const app = new App({
-    target: document.getElementById('app'),
-});
+let app;
+
+function init() {
+    const targetEl = document.getElementById('app');
+    
+    // There's an issue where this module occasionally gets called twice
+    // so make sure we're not adding to an already created app.
+    if(targetEl.childElementCount > 0) return;
+
+    app = new App({
+        target: targetEl,
+    });
+}
+
+init();
   
 export default app;


### PR DESCRIPTION
There's an inconsistent issue that occurs where main.js can sometimes load twice and create two apps.

This ensures only one app gets added to the root element.